### PR TITLE
Recursor

### DIFF
--- a/HonkSharp/Functional/Recursor.cs
+++ b/HonkSharp/Functional/Recursor.cs
@@ -1,0 +1,34 @@
+using HonkSharp.Fluency;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace HonkSharp.Functional
+{
+    public static class Recursors
+    {
+        public static Func<TIn, TOut> prec<TIn, TOut>(Func<TIn, Func<TIn, TOut>, TOut> recInfo)
+        {
+            TOut Inner(TIn arg)
+            {
+                return recInfo(arg, i => Inner(i));
+            }
+            return Inner;
+        }
+        
+        public static Func<TIn, TOut> mrec<TIn, TOut>(Func<TIn, Func<TIn, TOut>, TOut> recInfo)
+        {
+            var dict = new Dictionary<TIn, TOut>();
+            TOut Inner(TIn arg)
+            {
+                if (dict.TryGetValue(arg, out var res))
+                    return res;
+                res = recInfo(arg, i => Inner(i));
+                dict[arg] = res;
+                return res;
+            }
+            return Inner;
+        }
+    }
+}

--- a/Tests/Functional/RecursorTests.cs
+++ b/Tests/Functional/RecursorTests.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using FluentAssertions;
+using HonkSharp.Fluency;
+using HonkSharp.Functional;
+using Xunit;
+using static HonkSharp.Functional.Recursors;
+
+namespace Tests
+{
+    public class RecursorTests
+    {
+        [Fact]
+        public void Factorial()
+        {
+            Assert.Equal(120, 
+                prec<int, int>((i, fact) => i switch {
+                    0 => 1,
+                    var n => n * fact(n - 1)
+                })(5));
+        }
+        
+        [Fact]
+        public void Fibonacci()
+        {
+            Assert.Equal(1318412525, 
+                mrec<int, int>((i, fib) => i switch {
+                    0 or 1 => 1,
+                    var n => fib(n - 1) + fib(n - 2)
+                })(1000));
+        }
+    }
+}


### PR DESCRIPTION
#23 

Not sure about the API though. `prec` and `mrec` look closer to keywords, but still are semantically methods, so should start with capital (and maybe have a longer name?)
